### PR TITLE
Permission scope 'users:read' added and replaced 'chat:write:user' with 'chat:write'

### DIFF
--- a/action.php
+++ b/action.php
@@ -37,7 +37,7 @@
 
                 $post = array(
                     'token' => $team_token,
-                    'scopes' => "commands, chat:write:user",
+                    'scopes' => "commands, chat:write:user, users:read",
                     'trigger_id' => $payload["trigger_id"]
                 );
 

--- a/action.php
+++ b/action.php
@@ -37,7 +37,7 @@
 
                 $post = array(
                     'token' => $team_token,
-                    'scopes' => "commands, chat:write:user, users:read",
+                    'scopes' => "commands, chat:write, users:read",
                     'trigger_id' => $payload["trigger_id"]
                 );
 

--- a/events.php
+++ b/events.php
@@ -29,7 +29,7 @@
         $install_message = $GLOBALS['install_message'];
         $install_team_info = app_installs_get($postjson['team_id']);
 
-        if(in_array("commands", $scopes) && in_array("chat:write:user", $scopes)){
+        if(in_array("commands", $scopes) && in_array("chat:write:user", $scopes) && in_array("users:read", $scopes)){
             // The command and channel write scopes has been granted, update the install message accordingly.
             $install_message['attachments'] =  Array(
                 Array(

--- a/events.php
+++ b/events.php
@@ -29,7 +29,7 @@
         $install_message = $GLOBALS['install_message'];
         $install_team_info = app_installs_get($postjson['team_id']);
 
-        if(in_array("commands", $scopes) && in_array("chat:write:user", $scopes) && in_array("users:read", $scopes)){
+        if(in_array("commands", $scopes) && in_array("chat:write", $scopes) && in_array("users:read", $scopes)){
             // The command and channel write scopes has been granted, update the install message accordingly.
             $install_message['attachments'] =  Array(
                 Array(


### PR DESCRIPTION
Fix for point 1 of issue https://github.com/slackapi/lunchtrain/issues/4:

> It seems to be set to LA time zone (we're located in Berlin) resulting in a message like this one when I'm trying to add a lunch train for the next hour: "Ouch, we couldn't start this train. Your departure time should be with-in six hours from now."

My solution as stated in the issue:

> I've had the same issue as 1. (I'm located in the Netherlands).
> 
> After some debugging I've found the problem:
> 
> The app is requesting the timezone of the user through the Slack API. If it fails to that it reverts to "America/Los_Angeles".
> It fails because the app is missing the "users:read" permission scope (which isn't mentioned in the documentation and isn't present in the code).
> 
> The solution is:
> 
> Adding the "users:read" permission scope ("View the workspace's list of members and their contact information") in the OAuth settings of your Slack app
> Adding the "users:read" scope in actions.php:40
> Adding an in_array() check for the "users:read" scope in events.php:32
> Reinstall the app in your Slack workspace and channel